### PR TITLE
Change flashcard trigger color from orange to blue in Raindrop

### DIFF
--- a/CLAUDE_STATUS.md
+++ b/CLAUDE_STATUS.md
@@ -32,7 +32,7 @@
 │                        INPUT SOURCES                             │
 ├──────────────┬──────────────┬──────────────┬───────────────────┤
 │ Chrome Ext   │ Raindrop.io  │ Web UI       │ (Future: Alfred,  │
-│ (highlight)  │ (orange=card)│ (manual)     │  iOS Shortcuts)   │
+│ (highlight)  │ (blue=card)  │ (manual)     │  iOS Shortcuts)   │
 └──────┬───────┴──────┬───────┴──────┬───────┴───────────────────┘
        │              │              │
        ▼              ▼              ▼
@@ -59,7 +59,7 @@
 - [x] Card model (flashcards) with CRUD
 - [x] Tag model with many-to-many relationships
 - [x] Spaced repetition service (SM-2 algorithm)
-- [x] Raindrop.io sync service (fetches highlights, orange = flashcard)
+- [x] Raindrop.io sync service (fetches highlights, blue = flashcard)
 - [x] Ollama integration for card generation
 - [x] Obsidian export service (markdown files)
 - [x] Simple API key authentication

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A spaced repetition learning system with multiple input sources. Capture knowled
 ## Features
 
 - **Multiple Input Sources**
-  - Raindrop.io integration (orange highlights → flashcards)
+  - Raindrop.io integration (blue highlights → flashcards)
   - Chrome extension for quick capture
   - Manual entry via web UI
   - (Planned) Alfred workflow, iOS Shortcuts
@@ -138,7 +138,7 @@ OBSIDIAN_LEARNINGS_FOLDER=learnings
 1. Go to [Raindrop.io Settings → Integrations](https://app.raindrop.io/settings/integrations)
 2. Create a new app or use "Test Token"
 3. Copy the token to your `.env` file
-4. Use **orange highlights** in Raindrop to mark content for flashcard generation
+4. Use **blue highlights** in Raindrop to mark content for flashcard generation
 
 ### Chrome Extension
 
@@ -157,7 +157,7 @@ OBSIDIAN_LEARNINGS_FOLDER=learnings
 
 ### 1. Capture Knowledge
 
-- **Reading articles**: Use Raindrop.io with orange highlights
+- **Reading articles**: Use Raindrop.io with blue highlights
 - **Browsing**: Use Chrome extension to capture selections
 - **Manual**: Add sources directly in the web UI
 

--- a/backend/app/routers/sync.py
+++ b/backend/app/routers/sync.py
@@ -28,7 +28,7 @@ async def sync_raindrop(
 
     Args:
         since: Only sync highlights created after this datetime
-        auto_generate: If True, automatically generate cards for orange highlights
+        auto_generate: If True, automatically generate cards for blue highlights
     """
     service = RaindropService()
 

--- a/backend/app/services/raindrop.py
+++ b/backend/app/services/raindrop.py
@@ -2,7 +2,7 @@
 Raindrop.io Integration Service.
 
 Fetches highlights from Raindrop.io API and creates sources from them.
-Orange highlights trigger flashcard generation.
+Blue highlights trigger flashcard generation.
 """
 
 import httpx
@@ -16,7 +16,7 @@ class RaindropService:
     BASE_URL = "https://api.raindrop.io/rest/v1"
 
     # Highlight color that triggers flashcard generation
-    FLASHCARD_COLOR = "orange"
+    FLASHCARD_COLOR = "blue"
 
     def __init__(self, token: Optional[str] = None):
         self.token = token or settings.raindrop_token
@@ -89,7 +89,7 @@ class RaindropService:
         }
 
     def should_generate_cards(self, highlight: dict) -> bool:
-        """Check if a highlight should trigger card generation (orange color)."""
+        """Check if a highlight should trigger card generation (blue color)."""
         return highlight.get("color", "").lower() == self.FLASHCARD_COLOR
 
     async def sync_highlights(
@@ -99,7 +99,7 @@ class RaindropService:
         Sync highlights from Raindrop.
 
         Returns (all_highlights, flashcard_highlights) where flashcard_highlights
-        are the orange ones that should generate cards.
+        are the blue ones that should generate cards.
         """
         all_highlights = []
         flashcard_highlights = []


### PR DESCRIPTION
## Summary
Updated the Raindrop.io integration service to use blue highlights instead of orange highlights as the trigger for flashcard generation.

## Changes
- Changed `FLASHCARD_COLOR` constant from `"orange"` to `"blue"`
- Updated module docstring to reflect the new trigger color
- Updated method docstrings in `should_generate_cards()` and `sync_highlights()` to reference blue instead of orange

## Details
This change affects the highlight color detection logic in the Raindrop service. Users will now need to mark highlights in blue (instead of orange) in Raindrop.io to trigger automatic flashcard generation. The functionality remains the same; only the color identifier has been updated.

https://claude.ai/code/session_01BJQsLQHnpvzhsGoRkD2PxE